### PR TITLE
refactor(dynamic-approval): Simplify tool UI

### DIFF
--- a/dynamic-tool-approval/src/client/App.tsx
+++ b/dynamic-tool-approval/src/client/App.tsx
@@ -9,27 +9,28 @@ export interface ToolCall {
 }
 
 function ToolCallBox({ tc }: { tc: ToolCall }) {
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(tc.state === 'running');
+
+  useEffect(() => {
+    setIsOpen(tc.state === 'running');
+  }, [tc.state]);
   return (
     <div className="message tool-message">
       <div className="tool-box">
         <div className="tool-header">
-          <div key={`indicator-${tc.name}`} className="tool-indicator indicator-animate" />
           <div key={`label-${tc.name}`} className="tool-step-label step-animate">
-            Used tool: <code>{tc.name}</code>
+            {tc.state === 'running' ? 'Using' : 'Used'} tool: <code>{tc.name}</code>
           </div>
         </div>
         <details
           className="tool-details"
+          open={isOpen}
           onToggle={(e) => setIsOpen(e.currentTarget.open)}
         >
           <summary className="tool-summary">
             <span className="summary-text">
               {isOpen ? 'Hide Tool Details' : 'Show Tool Details'}
             </span>
-            {tc.state === 'running' && (
-              <span className="tool-status running">Running...</span>
-            )}
           </summary>
           <div className="tool-body">
             <div>Input: {JSON.stringify(tc.input, null, 2)}</div>

--- a/dynamic-tool-approval/src/client/style.css
+++ b/dynamic-tool-approval/src/client/style.css
@@ -183,29 +183,6 @@ body {
   gap: 12px;
 }
 
-/* (Optional) Adds an animated blue accent bar next to the tool name */
-.tool-indicator {
-  width: 4px;
-  height: 18px;
-  background-color: var(--accent-blue-light);
-  border-radius: 4px;
-  flex-shrink: 0;
-  transform-origin: bottom;
-}
-
-.tool-indicator.indicator-animate {
-  animation: growUpBar 0.25s ease-out forwards;
-}
-
-@keyframes growUpBar {
-  0% {
-    transform: scaleY(0);
-  }
-
-  100% {
-    transform: scaleY(1);
-  }
-}
 
 .tool-step-label {
   font-size: 15px;
@@ -289,18 +266,4 @@ body {
   font-family: 'Chivo Mono', 'Fira Code', Consolas, Monaco, monospace;
   max-height: 300px;
   overflow-y: auto;
-}
-
-.tool-status {
-  font-size: 11px;
-  padding: 2px 8px;
-  border-radius: 12px;
-  text-transform: uppercase;
-  font-weight: 600;
-  margin-left: 8px;
-}
-
-.tool-status.running {
-  background-color: rgba(59, 130, 246, 0.15);
-  color: var(--accent-blue);
 }


### PR DESCRIPTION
- Remove animated blue running indicator and "Running..." text
- Update tool label to dynamically say "Using tool:" vs "Used tool:"
- Add a `useEffect` to automatically expand the native `<details>` element while the tool is running, and automatically collapse it when finished
- Delete unused CSS classes