### PR TITLE
refactor(dynamic-approval): Remove deprecated custom chat flow

### DIFF
--- a/dynamic-tool-approval/src/client/App.tsx
+++ b/dynamic-tool-approval/src/client/App.tsx
@@ -5,7 +5,6 @@ export interface ToolCall {
   name: string;
   input: any;
   state: 'running' | 'completed';
-  output?: any;
   ref?: string;
 }
 
@@ -38,12 +37,6 @@ function ToolCallBox({ tc }: { tc: ToolCall }) {
           </summary>
           <div className="tool-body">
             <div>Input: {JSON.stringify(tc.input, null, 2)}</div>
-
-            {tc.output && (
-              <div style={{ marginTop: '12px', borderTop: '1px solid #27272a', paddingTop: '12px', whiteSpace: 'pre-wrap' }}>
-                Result: {typeof tc.output === 'object' ? JSON.stringify(tc.output, null, 2) : String(tc.output)}
-              </div>
-            )}
           </div>
         </details>
       </div>

--- a/dynamic-tool-approval/src/server/index.ts
+++ b/dynamic-tool-approval/src/server/index.ts
@@ -82,40 +82,7 @@ app.get('/api/health', (req: Request, res: Response) => {
 
 import { expressHandler } from '@genkit-ai/express';
 
-export const chatFlow = ai.defineFlow({
-  name: 'chatFlow',
-  inputSchema: z.object({
-    messages: z.array(z.any()),
-  }),
-  streamSchema: z.object({
-    text: z.string().optional(),
-    toolRequest: z.any().optional(),
-    toolResponse: z.any().optional(),
-  }),
-}, async (input, { sendChunk }) => {
-  const { stream, response } = await ai.generateStream({
-    model: googleAI.model('gemini-3.5-flash'),
-    messages: input.messages,
-    tools: [readCoffeeMenu, orderCoffee], // Register tools
-    config: {
-      thinkingConfig: {
-        thinkingLevel: 'MINIMAL',
-      },
-    },
-  });
 
-  for await (const chunk of stream) {
-    for (const part of chunk.content || []) {
-      sendChunk(part);
-    }
-  }
-
-  const finalResponse = await response;
-  return finalResponse.text;
-});
-
-// POST /api/chat generation route
-app.post('/api/chat', expressHandler(chatFlow));
 
 // POST /api/agent native genkit agent route
 app.post('/api/agent', expressHandler(coffeeAgent));


### PR DESCRIPTION
Delete the old `chatFlow` and the `/api/chat` route.